### PR TITLE
Add *Noto Sans Modi* font for the Modi Script

### DIFF
--- a/unicode-fonts.el
+++ b/unicode-fonts.el
@@ -1421,6 +1421,7 @@
     ("Noto Sans Malayalam UI"              :licenses (free))
     ("Noto Sans Mandaic"                   :licenses (free))
     ("Noto Sans Meetei Mayek"              :licenses (free))
+    ("Noto Sans Modi"                      :licenses (free))
     ("Noto Sans Mongolian"                 :licenses (free))
     ("Noto Sans Myanmar"                   :licenses (free))
     ("Noto Sans Myanmar UI"                :licenses (free))
@@ -3407,6 +3408,7 @@ Set to nil to disable."
                                                          ))
     ("Modi"                                             (
                                                          "MarathiCursiveG"              ; 79/79
+                                                         "Noto Sans Modi"               ; 79/79
                                                          ))
     ("Modifier Tone Letters"                            (
                                                          "Apple Symbols"                ; 27/32


### PR DESCRIPTION
This pull request allows for Emacs to pick up the Noto Sans Modi font to display Unicode characters representing the Modi script. 