### PR TITLE
Fix error wherein symbol \... breaks startup

### DIFF
--- a/unicode-fonts.el
+++ b/unicode-fonts.el
@@ -574,7 +574,6 @@
 
 ;; for cl-callf, cl-member, cl-incf, cl-remove-if, cl-remove-if-not, cl-assert, cl-loop, cl-copy-list
 (require 'cl-lib)
-(require 'seq)
 
 (autoload 'persistent-soft-store               "persistent-soft" "Under SYMBOL, store VALUE in the LOCATION persistent data store."    )
 (autoload 'persistent-soft-fetch               "persistent-soft" "Return the value for SYMBOL in the LOCATION persistent data store."  )
@@ -5108,7 +5107,7 @@ and regenerated."
           (cl-map 'list 
                   (lambda (x) 
                     (cons (car x) ;; get rid of symbols such as '\...
-                          (seq-filter #'consp (cdr x))))
+                          (cl-remove-if-not #'consp (cdr x))))
                   unicode-fonts--instructions))
     (eval
       (append

--- a/unicode-fonts.el
+++ b/unicode-fonts.el
@@ -574,6 +574,7 @@
 
 ;; for cl-callf, cl-member, cl-incf, cl-remove-if, cl-remove-if-not, cl-assert, cl-loop, cl-copy-list
 (require 'cl-lib)
+(require 'seq)
 
 (autoload 'persistent-soft-store               "persistent-soft" "Under SYMBOL, store VALUE in the LOCATION persistent data store."    )
 (autoload 'persistent-soft-fetch               "persistent-soft" "Return the value for SYMBOL in the LOCATION persistent data store."  )
@@ -5103,9 +5104,15 @@ Optional REGENERATE requests that the disk cache be invalidated
 and regenerated."
   (when (display-multi-font-p)
     (unicode-fonts--load-or-generate-instructions fontset-name regenerate)
+    (setq unicode-fonts--instructions
+          (cl-map 'list 
+                  (lambda (x) 
+                    (cons (car x) ;; get rid of symbols such as '\...
+                          (seq-filter #'consp (cdr x))))
+                  unicode-fonts--instructions))
     (eval
-     (append
-      '(progn) (cdr (assoc fontset-name unicode-fonts--instructions))))
+      (append
+        '(progn) (cdr (assoc fontset-name unicode-fonts--instructions))))
     ;; clean up the evaluated code, as it may be very large
     (setq unicode-fonts--instructions
           (delq (assoc fontset-name unicode-fonts--instructions) unicode-fonts--instructions))))


### PR DESCRIPTION
Filter on unicode-fonts--instructions after unicode-fonts--load-or-generate-instructions in order to prevent \... from being included in the eval'ed code and breaking emacs startup for me